### PR TITLE
Fix versioning for 1.20 with new OPC update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,8 @@ jei_version=8.0.0.16
 mappingsChannel=official
 mappingsVersion=1.20
 
+usesMCVersionOrderFirst=true
+
 requiredCurseDependencies=blockui
 
 githubUrl=


### PR DESCRIPTION
See https://github.com/ldtteam/OperaPublicaCreator/pull/30